### PR TITLE
Add Command Category 'Joplin'

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
         "icon": {
           "light": "resources/light/refresh.svg",
           "dark": "resources/dark/refresh.svg"
-        }
+        },
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.createFolder",
@@ -69,7 +70,8 @@
         "icon": {
           "light": "resources/light/new-folder.svg",
           "dark": "resources/dark/new-folder.svg"
-        }
+        },
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.createNote",
@@ -77,7 +79,8 @@
         "icon": {
           "light": "resources/light/new-file.svg",
           "dark": "resources/dark/new-file.svg"
-        }
+        },
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.rename",
@@ -85,7 +88,8 @@
         "icon": {
           "light": "resources/light/edit.svg",
           "dark": "resources/dark/edit.svg"
-        }
+        },
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.remove",
@@ -93,15 +97,18 @@
         "icon": {
           "light": "resources/light/trash.svg",
           "dark": "resources/dark/trash.svg"
-        }
+        },
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.copyLink",
-        "title": "%commands.joplinNote.copyLink%"
+        "title": "%commands.joplinNote.copyLink%",
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.toggleTodoState",
-        "title": "%commands.joplinNote.toggleTodoState%"
+        "title": "%commands.joplinNote.toggleTodoState%",
+        "category": "Joplin"
       },
       {
         "command": "joplinNote.search",
@@ -109,16 +116,19 @@
         "icon": {
           "light": "resources/light/search.svg",
           "dark": "resources/dark/search.svg"
-        }
+        },
+        "category": "Joplin"
       },
       {
-        "command": "joplin.uploadImageFromClipboard",
+        "command": "joplinNote.uploadImageFromClipboard",
         "title": "%commands.joplinNote.uploadImageFromClipboard%",
-        "when": "resourceLangId == markdown && resourceFilename =~ /^edit-.*\\.md/ && editorTextFocus"
+        "when": "resourceLangId == markdown && resourceFilename =~ /^edit-.*\\.md/ && editorTextFocus",
+        "category": "Joplin"
       },
       {
-        "command": "joplin.uploadImageFromExplorer",
-        "title": "%commands.joplinNote.uploadImageFromExplorer%"
+        "command": "joplinNote.uploadImageFromExplorer",
+        "title": "%commands.joplinNote.uploadImageFromExplorer%",
+        "category": "Joplin"
       }
     ],
     "menus": {
@@ -190,13 +200,13 @@
         "when": "focusedView == joplin-note"
       },
       {
-        "command": "joplin.uploadImageFromClipboard",
+        "command": "joplinNote.uploadImageFromClipboard",
         "key": "ctrl+alt+u",
         "mac": "cmd+alt+u",
         "when": "editorTextFocus && editorLangId == markdown"
       },
       {
-        "command": "joplin.uploadImageFromExplorer",
+        "command": "joplinNote.uploadImageFromExplorer",
         "key": "ctrl+alt+e",
         "mac": "cmd+alt+e",
         "when": "editorTextFocus && editorLangId == markdown"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,11 +85,11 @@ export async function activate(context: vscode.ExtensionContext) {
   //region register image upload
 
   vscode.commands.registerCommand(
-    'joplin.uploadImageFromClipboard',
+    'joplinNote.uploadImageFromClipboard',
     uploadImageService.uploadImageFromClipboard.bind(uploadImageService),
   )
   vscode.commands.registerCommand(
-    'joplin.uploadImageFromExplorer',
+    'joplinNote.uploadImageFromExplorer',
     uploadImageService.uploadImageFromExplorer.bind(uploadImageService),
   )
 


### PR DESCRIPTION
This makes it easier to distinguish the Joplin commands from VScode commands in Command Palette.

It also makes it easier to search for and assign Keyboard shortcuts for Joplin-Plugin commands.