### PR TITLE
Add View:Show-Joplin key and View:Toggle-Panel key. Update quick-start.

### DIFF
--- a/docs/_navbar/get-started/quick-start.md
+++ b/docs/_navbar/get-started/quick-start.md
@@ -1,28 +1,77 @@
 # Quick start
+## Overview
 
-> This tutorial assumes that you are already familiar with VSCode, its Markdown environment, and the use of Joplin, just to quickly understand how to use plugins to combine them. If you have never contacted Joplin/VSCode, please check [Related Documents](_navbar/other/why).
+`joplin-vscode-plugin` offers editing and management of Joplin notes with the power and flexibility of VSCode.
 
-## Claim
+ Joplin Web Clipper is designed to communicate with browser extensions by sharing Notes, Notebooks, Tags, etc. through a REST web API. `joplin-vscode-plugin` connects to that same REST endpoint to freely make changes to your notes without ever leaving the editor.
 
-- Joplin version> v1.4.19
-- VSCode version> v1.45.0
+> Why does this plugin exist? Read [my motivation](_navbar/other/why) for developing it.
+>
+> What can it do? The [roadmap](_navbar/other/roadmap) lists both existing and planned features.
+>
+> Never heard of [Joplin](https://joplinapp.org/)? You're missing out on a great [opensource synchronized note taking app](https://joplinapp.org/).
+## Requirements
+
+- Joplin version > v1.4.19
+- VSCode version > v1.45.0
+- Joplin Web Clipper enabled
+- Basic familiarity with using both Joplin and VS Code
 
 ## Install Joplin VSCode plugin
 
-Search for Joplin in VSCode's plug-in market and click install. After a while, the plug-in should be installed.
+Search for "Joplin" in the VSCode Marketplace. Find "joplin-vscode-plugin" and click Install.
 
 ![install plugin](../../_media/install-plugin.png)
 
-## Configure plugin
+## Configure
 
-> Make sure you have enabled the Web Clipper service, refer to: [Joplin Web Clipper](https://joplinapp.org/clipper/)
 
-Next, you need to configure the Joplin port and token for the plug-in. Generally, the port defaults to 41184. No configuration is required, just configure the token.
+To access the Joplin database, we need a connection to the API endpoint opened by Joplin Web Clipper. That means Joplin must be running and Web Clipper must be enabled.
+
+> For help with Web Clipper refer to: [Joplin Web Clipper](https://joplinapp.org/clipper/).
+
+Two settings need attention to get up and running.
+
+`Port`  
+* Copy the port number from Joplin settings and paste it here. The active port displays when Web Clipper is enabled:  
+**Web Clipper -> Step 1: Enable the clipper service -> Status**
+
+`Token`  
+* Copy your Authorization token from Joplin settings and paste it here:  
+**Web Clipper -> Advanced options -> Authorization Token**
 
 ![install plugin](../../_media/joplin-settings.png)
 
 ## Restart VSCode
 
-For some reasons, currently Joplin cannot take effect immediately after configuration. You need to close VSCode and restart to reload the configuration.
+Currently configuration edits do not trigger a fresh connection. Simply close VSCode and it should connect to Joplin the next time you start.
+
+---
+
+## Say Hello Joplin
+
+Type the key chord <kbd>Ctrl</kbd>+<kbd>J</kbd> <kbd>Ctrl</kbd>+<kbd>J</kbd> and celebrate. :tada: That hotkey combo activates the *View: Show Joplin* command, opening the Sidebar to reveal all your Notebooks.
 
 ![preview](https://cdn.jsdelivr.net/gh/rxliuli/img-bed/20200623085740.png)
+
+## Usage
+
+All your Notes and Noteboks can be found in the Sidebar. Unfold the Notebooks to see Subnotebooks and Notes beneath.
+
+*Click on a Note to open a working copy in the Editor. Save it to push changes back to Joplin.*
+
+You have full access to create, edit, and delete both Notes and Notebooks, at your whim. And it doesn't even stop there. The power is yours now. 🦸‍♀️
+
+> Tip: Explore the results of typing "joplin" in the Command Palette to find out what great features I didn't tell you about.
+
+## Commands and keybindings
+
+VSCode has *a lot* of keybindings. To avoid constantly clashing with all the built in settings, we laid claim to just one desirable hotekey, <kbd>Ctrl</kbd>+<kbd>J</kbd>, and turned that into the trigger for a key chord.
+
+> Claiming <kbd>Ctrl</kbd>+<kbd>J</kbd> displaced the native binding for `workbench.action.togglePanel` (*View: Toggle Panel*). For your convenience a sane replacement binding is already added at <kbd>Ctrl</kbd>+<kbd>K</kbd> <kbd>Ctrl</kbd>+<kbd>J</kbd>.
+
+Type `Joplin` into the Command Palette (<kbd>Ctrl</kbd>+<kbd>P</kbd>) to see all the new commands available to you. Some of them already have keybindings. Assign new bindings under the <kbd>Ctrl</kbd>+<kbd>J</kbd> namespace to fit your needs.
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -251,6 +251,14 @@
     },
     "keybindings": [
       {
+        "command": "workbench.action.togglePanel",
+        "key": "ctrl+k ctrl+j"
+      },
+      {
+        "command": "workbench.view.extension.joplin-note",
+        "key": "ctrl+j ctrl+j"
+      },
+      {
         "key": "f2",
         "command": "joplinNote.rename",
         "when": "focusedView == joplin-note"


### PR DESCRIPTION
Provide keybinding for View: Show Joplin at `Ctrl+J Ctrl+J`. Add a sensible replacement binding for clobbered command `workbench.action.togglePanel` at `Ctrl+K Ctrl+J`.

Update quick-start by fleshing out with more detail. Of particular importance is describing where to find the Authorization token in Joplin Desktop and explaining away the clobbering of `Ctrl+J` system keybinding. Broke up text in a way that gives the impression of good document formatting despite the constraints of markdown.